### PR TITLE
Fix event handler

### DIFF
--- a/src/lib/event_handler.py
+++ b/src/lib/event_handler.py
@@ -1,5 +1,6 @@
 class EventHandler:
-    event_listeners = []
+    def __init__(self):
+        self.event_listeners = []
 
     def add(self, listener):
         self.event_listeners.append(listener)

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -21,3 +21,20 @@ class EventHandlerTest(TestCase):
         listener_1.assert_called_once_with("foo", bar="baz")
         listener_2.assert_called_once_with("foo", bar="baz")
         listener_3.assert_called_once_with("foo", bar="baz")
+
+    @staticmethod
+    def test_all_events_called_on_invoke():
+        my_handler_1 = EventHandler()
+        my_handler_2 = EventHandler()
+
+        listener_1 = mock.Mock()
+        listener_2 = mock.Mock()
+
+        my_handler_1.add(listener_1)
+        my_handler_2.add(listener_2)
+
+        my_handler_1.invoke("foo")
+
+        listener_1.assert_called_once_with("foo")
+        listener_2.assert_not_called()
+        print(listener_2.event_listeners)

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -37,4 +37,3 @@ class EventHandlerTest(TestCase):
 
         listener_1.assert_called_once_with("foo")
         listener_2.assert_not_called()
-        print(listener_2.event_listeners)

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -23,7 +23,7 @@ class EventHandlerTest(TestCase):
         listener_3.assert_called_once_with("foo", bar="baz")
 
     @staticmethod
-    def test_all_events_called_on_invoke():
+    def test_event_handlers_do_not_leak():
         my_handler_1 = EventHandler()
         my_handler_2 = EventHandler()
 


### PR DESCRIPTION
fixes a bug. TIL that defining variables at the top level makes them static. need to put them in the __init__. Adds a test for this regression