### PR TITLE
Reopen render config bugfix

### DIFF
--- a/src/widgets/renderer_widget.py
+++ b/src/widgets/renderer_widget.py
@@ -48,6 +48,7 @@ class RendererWidget(BaseWidget):
         self.render_options()
 
         self.root.image_controller.selected_image_eh.add(self.on_image_change)
+        self.on_image_change(self.root.image_controller.get_selected_image())
 
     def histogram(self):
         self.histogram_main_frame = tb.Frame(self, bootstyle="light")


### PR DESCRIPTION
fixes a render config bug where if you close and reopen the render config the fields are not filled out. fixed by manually calling the event listener to update everything