### PR TITLE
Support running on a Linux machine

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import tkinter as tk
 
@@ -11,6 +12,8 @@ DPI = 150
 if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
     # Running from a compiled executable
     ASSETS_FOLDER = os.path.join(sys._MEIPASS, "resources", "assets")
+elif platform.system() == "Linux":
+    ASSETS_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources", "assets"))
 else:
     ASSETS_FOLDER = os.path.join(os.path.dirname(__file__), "..", "resources", "assets")
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,6 +2,7 @@ import os
 import platform
 import sys
 import tkinter as tk
+from PIL import Image, ImageTk
 
 PERCENTILES = [90, 95, 99, 99.5, 99.9, 100]
 DPI = 150
@@ -19,8 +20,7 @@ else:
 
 ICONPNG_PATH = os.path.join(ASSETS_FOLDER, "favicon-32x32.png")
 ICONPNG = None
-
-FAVICON_PATH = os.path.join(ASSETS_FOLDER, "favicon.ico")
+FAVICON = None
 
 
 def load_images():
@@ -29,3 +29,15 @@ def load_images():
     """
     global ICONPNG
     ICONPNG = tk.PhotoImage("photo", file=ICONPNG_PATH)
+
+    global FAVICON
+    favicon_path = os.path.join(ASSETS_FOLDER, "favicon.ico")
+    if platform.system() == "Linux":
+        """
+        .ico file cannot be used as an icon file in Linux. 
+        It needs to be opened from PIL instead.
+        """
+        im = Image.open(favicon_path)
+        FAVICON = ImageTk.PhotoImage(im)
+    else:
+        FAVICON = tk.PhotoImage("favicon", file=favicon_path)

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import tkinter as tk
 import ttkbootstrap as tb
 
 import src.constants as constants
+import platform
 from src.menu_bar import MenuBar
 from src.widgets import widget_controller as wc
 from src.widgets.image import image_controller as ic
@@ -20,7 +21,12 @@ class MainWindow(tb.Window):
 
         self.title("EMU Viewer")
         self.iconphoto(True, constants.ICONPNG)
-        self.iconbitmap(constants.FAVICON_PATH)  # windows title icon
+
+        if platform.system() == "Linux":
+            self.iconphoto(True, constants.FAVICON)
+        else:
+            self.iconbitmap(constants.FAVICON)  # windows title icon
+
         self.geometry("800x800")
 
         self.grid_rowconfigure(0, weight=1)

--- a/src/widgets/base_widget.py
+++ b/src/widgets/base_widget.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import platform
 import ttkbootstrap as tb
 
 from src import constants
@@ -23,7 +24,15 @@ class BaseWidget(tb.Toplevel):
 
         self.title(self.__class__.label)
         self.resizable(False, False)
-        self.iconbitmap(constants.FAVICON_PATH)  # windows title icon
+
+        if platform.system() == "Linux":
+            """
+            .ico file cannot be used as an icon file in Linux. 
+            iconphoto() method is needed instead of iconbitmap().
+            """
+            self.iconphoto(True, constants.FAVICON)
+        else:
+            self.iconbitmap(constants.FAVICON)  # windows title icon
 
         self.on_close_eh = EventHandler()
 

--- a/src/widgets/image/image_standalone_toplevel.py
+++ b/src/widgets/image/image_standalone_toplevel.py
@@ -1,3 +1,4 @@
+import platform
 import tkinter as tk
 from functools import partial
 from typing import TYPE_CHECKING, Optional
@@ -46,7 +47,11 @@ class StandaloneImage(tk.Toplevel):
 
         self.title(file_name)
         self.geometry("800x600")
-        self.iconbitmap(constants.FAVICON_PATH)  # windows title icon
+
+        if platform.system() == "Linux":
+            self.iconphoto(True, constants.FAVICON)
+        else:
+            self.iconbitmap(constants.FAVICON)  # windows title icon
 
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)


### PR DESCRIPTION
1. For allowing going up a directory, probably worth looking at a more cross platform methods like `os.pardir` 
2. Tkinter does not allow .ico file to be used as icons in linux. PIL on the other hand gives greater compatibility.